### PR TITLE
Insert session if update doesn't update any rows

### DIFF
--- a/test/jdbc_ring_session/core_test.clj
+++ b/test/jdbc_ring_session/core_test.clj
@@ -37,4 +37,9 @@
     (let [store (jdbc-store db)
           data {:foo "bar" :bar [1 2 3]}
           k    (.write-session store nil data)]
-      (is (= data (.read-session store k))))))
+      (is (= data (.read-session store k)))
+
+      (testing "same session-id is reused after it has expired (deleted)"
+        (.delete-session store k)
+        (.write-session store k data)
+        (is (= data (.read-session store k)))))))


### PR DESCRIPTION
Write-session can be called with session-id that doesn't exist in
session-store if the session has expired and row removed by cleaner. In
this case UPDATE query does nothing, and the row should be INSERTed with
given key.